### PR TITLE
Fixed unbound this

### DIFF
--- a/chrome-extension-async.js
+++ b/chrome-extension-async.js
@@ -86,7 +86,7 @@
             const m = api[funcName];
             if (typeof m === 'function')
                 // This is a function, wrap in a promise
-                api[funcName] = promisify(m, funcDef.cb);
+                api[funcName] = promisify(m.bind(api), funcDef.cb);
             else
                 // Sub-API, recurse this func with the mapped props
                 applyMap(m, funcDef.props);


### PR DESCRIPTION
Some versions of Chrome threw the error `TypeError: Illegal invocation: Function must be called on an object of type StorageArea` when attempting to use `chrome.storage` functions that had been wrapped with this library.

Fixes #10