### PR TITLE
Implement chrome.tabs createAndWait and reloadAndWait async functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,13 +159,13 @@ This relies on a `chrome.runtime.onMessage.addListener` subscription, so it will
 
 ### Create and Reload Tabs with `chrome.tabs.createAndWait` and `chrome.tabs.reloadAndWait`
 
-The normal `chrome.tabs.create` and `chrome.tabs.reload` functions executes their callbacks before the tab is finished loading. This makes it difficult to create or reload a tab, and then execute a content script on the page.  `chrome.tabs.createAndWait` and `chrome.tabs.reloadAndWait` are an enhancement to the tabs API that waits until the tab has finished loading the url, and is ready to execute scripts.  They pair great with `chrome.tabs.executeAsyncFunction`. They:
+The normal `chrome.tabs.create` and `chrome.tabs.reload` functions execute their callbacks before the tab is finished loading. This makes it difficult to create or reload a tab, and then execute a content script on the page.  `chrome.tabs.createAndWait` and `chrome.tabs.reloadAndWait` are an enhancement to the tabs API that waits until the tab has finished loading the url, and is ready to execute scripts.  They pair great with `chrome.tabs.executeAsyncFunction`. They:
 
 - Call `chrome.tabs.create` or `chrome.tabs.reload`, await the results, and grab the tab's id.
 - Use `chrome.tabs.onUpdated.addListener` to listen for the 'completed' status for the tab's id.
 - Wrap the whole thing in a promise that resolves with the final result.
 - Use `chrome.tabs.onRemoved.addListener` and `chrome.tabs.onReplaced.addListener` to detect if the tab is removed or replaced before the loading finishes, and rejects the promise with an Error.
-- Use an auto-timeout of 2 minutes.  If the page doesn't load in 120 seconds, or one of the three listeners is never called, the promise will be rejected with an Error.
+- Use an auto-timeout feature. If the page doesn't load in the specified milliseconds, or one of the three listeners is never called, the promise will be rejected with an Error. The value of the timeout is configurable with an optional parameter. The default value is 12e4 milliseconds (2 minutes). 
 
 `chrome.tabs.createAndWait` takes in the same parameters as [chrome.tabs.create](https://developer.chrome.com/extensions/tabs#method-create) except for the callback, and returns an object containing the same properties as the parameters passed to the callback for the [chrome.tabs.onUpdated](https://developer.chrome.com/extensions/tabs#event-onUpdated) event.
 

--- a/execute-async-function.d.ts
+++ b/execute-async-function.d.ts
@@ -17,4 +17,21 @@ declare namespace chrome.tabs {
      * @returns {Promise} Resolves when the injected async script has finished executing and holds the result of the script.
      * Rejects if an error is encountered setting up the function, if an error is thrown by the executing script, or if it times out. */
     export function executeAsyncFunction(tab: number, action: ((...p: any[]) => any) | string | InjectAsyncDetails, ...params: any[]): Promise<any>;
+
+    /** Creates a Promise that resolves only when the created tab is finished loading.
+     * The normal chrome.tabs.create function executes its' callback before the tab finishes loading the page.
+     * @param {object} createProperties same as the createProperties param for [chrome.tabs.create]{@link https://developer.chrome.com/extensions/tabs#method-create}.
+     * @returns {Promise} Resolves when the created tab has finished loading and holds the result.
+     * The result is an object containing the parameters passed to the callback for [chrome.tabs.onUpdated]{@link https://developer.chrome.com/extensions/tabs#event-onUpdated}.
+     * Rejects if an error is encountered loading the tab, or if it times out. */
+    export function createAndWait(createProperties: object): Promise<any>;
+
+    /** Creates a Promise that resolves only when the tab is finished reloading.
+     * The normal chrome.tabs.reload function executes its' callback before the tab finishes loading the page.
+     * @param {integer} tabId same as the tabId parameter for [chrome.tabs.reload]{@link https://developer.chrome.com/extensions/tabs#method-reload}.
+     * @param {object} reloadProperties Optional. same as the reloadProperties parameter for [chrome.tabs.reload]{@link https://developer.chrome.com/extensions/tabs#method-reload}.
+     * @returns {Promise} Resolves when the tab has finished reloading and holds the result.
+     * The result is an object containing the parameters passed to the callback for [chrome.tabs.onUpdated]{@link https://developer.chrome.com/extensions/tabs#event-onUpdated}.
+     * Rejects if an error is encountered loading the tab, or if it times out. */
+    export function reloadAndWait(tabId: number, reloadProperties: object): Promise<any>;
 }

--- a/execute-async-function.d.ts
+++ b/execute-async-function.d.ts
@@ -21,17 +21,21 @@ declare namespace chrome.tabs {
     /** Creates a Promise that resolves only when the created tab is finished loading.
      * The normal chrome.tabs.create function executes its' callback before the tab finishes loading the page.
      * @param {object} createProperties same as the createProperties param for [chrome.tabs.create]{@link https://developer.chrome.com/extensions/tabs#method-create}.
+     * @param {number} msTimeout Optional milliseconds to timeout when tab is loading
+     * If this value is null or zero, it defaults to 120,000 ms (2 minutes).
      * @returns {Promise} Resolves when the created tab has finished loading and holds the result.
      * The result is an object containing the parameters passed to the callback for [chrome.tabs.onUpdated]{@link https://developer.chrome.com/extensions/tabs#event-onUpdated}.
      * Rejects if an error is encountered loading the tab, or if it times out. */
-    export function createAndWait(createProperties: object): Promise<any>;
+    export function createAndWait(createProperties: object, msTimeout: number): Promise<any>;
 
     /** Creates a Promise that resolves only when the tab is finished reloading.
      * The normal chrome.tabs.reload function executes its' callback before the tab finishes loading the page.
      * @param {integer} tabId same as the tabId parameter for [chrome.tabs.reload]{@link https://developer.chrome.com/extensions/tabs#method-reload}.
      * @param {object} reloadProperties Optional. same as the reloadProperties parameter for [chrome.tabs.reload]{@link https://developer.chrome.com/extensions/tabs#method-reload}.
+     * @param {number} msTimeout Optional milliseconds to timeout when tab is loading
+     * If this value is null or zero, it defaults to 120,000 ms (2 minutes).
      * @returns {Promise} Resolves when the tab has finished reloading and holds the result.
      * The result is an object containing the parameters passed to the callback for [chrome.tabs.onUpdated]{@link https://developer.chrome.com/extensions/tabs#event-onUpdated}.
      * Rejects if an error is encountered loading the tab, or if it times out. */
-    export function reloadAndWait(tabId: number, reloadProperties: object): Promise<any>;
+    export function reloadAndWait(tabId: number, reloadProperties: object, msTimeout: number): Promise<any>;
 }

--- a/execute-async-function.js
+++ b/execute-async-function.js
@@ -52,47 +52,84 @@
         return execArgs;
     }
 
-    /** Create a promise that resolves when a chrome event (such as chrome.runtime.onMessage) fires
-     * @param {Event} chromeEvent The event type.
+    /** Create a promise that resolves when chrome.runtime.onMessage fires with the id
      * @param {string} id ID for the message we're expecting.
      * Messages without the ID will not resolve this promise.
      * @returns {Promise} Promise that resolves when chrome.runtime.onMessage.addListener fires. */
-    function promisifyChromeEvent(chromeEvent, id) {
-        // // We don't have a reject because the finally in the script wrapper should ensure this always gets called.
-        // We don't have a reject because this should be designed to always get called.
+    function promisifyRuntimeMessage(id) {
+        // We don't have a reject because the finally in the script wrapper should ensure this always gets called.
         return new Promise(resolve => {
-            const listener = function(...params) {
-                
-                if (chromeEvent === chrome.tabs.onUpdated) {
-                    const tabId = params[0];
-                    const changeInfo = params[1];
-                    const tab = params[2];
-                    // onUpdated event is called multiple times during a single load.
-                    // the status of 'complete' is called only once, when it is finished.
-                    if (tabId === id && changeInfo.status === 'complete') { 
-                        // Remove this listener
-                        chromeEvent.removeListener(listener);
-                        resolve({
-                            tabId: tabId,
-                            changeInfo: changeInfo,
-                            tab: tab
-                        });
-                    }
-                } else { // if (chromeEvent === 'chrome.runtime.onMessage')
-                    // Check that the message sent is intended for this listener
-                    if (!!params && !!params[0] && params[0].asyncFuncID === id) {
-                        // Remove this listener
-                        chromeEvent.removeListener(listener);
-                        resolve(params[0]);
-                    }
+            const listener = request => {
+                // Check that the message sent is intended for this listener
+                if (request && request.asyncFuncID === id) {
+
+                    // Remove this listener
+                    chrome.runtime.onMessage.removeListener(listener);
+                    resolve(request);
                 }
 
                 // Return false as we don't want to keep this channel open https://developer.chrome.com/extensions/runtime#event-onMessage
                 return false;
             };
 
-            chromeEvent.addListener(listener);
+            chrome.runtime.onMessage.addListener(listener);
         });
+    }
+
+    /** Create a promise that resolves when chrome.tabs.onUpdated fires with the id
+     * @param {string} id ID for the tab we're expecting.
+     * Tabs without the ID will not resolve or reject this promise.
+     * @returns {Promise} Promise that resolves when chrome.tabs.onUpdated.addListener fires. */
+    function promisifyTabUpdate(id) {
+
+        let mainPromise = new Promise((resolve, reject) => {
+            const tabUpdatedListener = (tabId, changeInfo, tab) => {
+                // The onUpdated event is called multiple times during a single load.
+                // the status of 'complete' is called only once, when it is finished.
+                if (tabId === id && changeInfo.status === 'complete') {
+                    removeListeners();
+                    resolve({tabId:tabId, changeInfo:changeInfo, tab:tab});
+                }
+            };
+
+            // This will happen when the tab or window is closed before it finishes loading
+            const tabRemovedListener = (tabId, removeInfo) => {
+                if (tabId === id) {
+                    removeListeners();
+                    reject(new Error(`The tab with id = ${tabId} was removed before it finished loading.`));
+                }
+            }
+
+            // This will happen when the tab is replaced.  This is untested, not sure how to recreate it.
+            const tabReplacedListener = (addedTabId, removedTabId) => {
+                if (removedTabId === id) {
+                    removeListeners();
+                    reject(new Error(`The tab with id = ${removedTabId} was replaced before it finished loading.`));
+                }
+            }
+
+            const removeListeners = () => {
+                chrome.tabs.onUpdated.removeListener(tabUpdatedListener);
+                chrome.tabs.onRemoved.removeListener(tabRemovedListener);
+                chrome.tabs.onReplaced.removeListener(tabReplacedListener);
+            }
+
+            chrome.tabs.onUpdated.addListener(tabUpdatedListener);
+            chrome.tabs.onRemoved.addListener(tabRemovedListener);
+            chrome.tabs.onReplaced.addListener(tabReplacedListener);
+        });
+
+        // Although I have onRemoved and onReplaced events watching to reject the promise,
+        // there is nothing in the chrome extension api documentation that guarantees this will be an exhaustive approach.
+        // So to account for the unknown, I am adding an auto-timeout feature to reject the promise after 2 minutes.
+        let timeoutPromise = new Promise ( (resolve, reject) => {
+            const secondsToTimeout = 120;
+            setTimeout(() => {
+                reject(new Error(`The tab loading timed out after ${secondsToTimeout} seconds.`));
+            }, secondsToTimeout * 1000);
+        });
+
+        return Promise.race([mainPromise, timeoutPromise]);
     }
 
     /** Execute an async function and return the result.
@@ -113,7 +150,7 @@
         const details = setupDetails(action, id, params);
 
         // Add a listener so that we know when the async script finishes
-        const message = promisifyChromeEvent(chrome.runtime.onMessage, id);
+        const message = promisifyRuntimeMessage(id);
 
         // This will return a serialised promise, which will be broken (http://stackoverflow.com/questions/43144485)
         await chrome.tabs.executeScript(tab, details);
@@ -128,18 +165,29 @@ Stack: ${error.stack}`)
         return content;
     }
 
+    /** Creates a Promise that resolves only when the created tab is finished loading.
+     * The normal chrome.tabs.create function executes its' callback before the tab finishes loading the page.
+     * @param {object} createProperties same as the createProperties param for [chrome.tabs.create]{@link https://developer.chrome.com/extensions/tabs#method-create}.
+     * @returns {Promise} Resolves when the created tab has finished loading and holds the result.
+     * The result is an object containing the parameters passed to the callback for [chrome.tabs.onUpdated]{@link https://developer.chrome.com/extensions/tabs#event-onUpdated}.
+     * Rejects if an error is encountered loading the tab, or if it times out. */
     chrome.tabs.createAndWait = async function(createProperties) {
-        // TODO: implement error handling - and maybe surround all awaits in try-catch block?
-        //       or it might be OK, even preferred, to let the errors bubble up.
         const tab = await chrome.tabs.create(createProperties);
-        const tabLoadCompletePromise = promisifyChromeEvent(chrome.tabs.onUpdated, tab.id);
+        const tabLoadCompletePromise = promisifyTabUpdate(tab.id);
         const results = await tabLoadCompletePromise;
         return results;
     }
 
+    /** Creates a Promise that resolves only when the tab is finished reloading.
+     * The normal chrome.tabs.reload function executes its' callback before the tab finishes loading the page.
+     * @param {integer} tabId same as the tabId parameter for [chrome.tabs.reload]{@link https://developer.chrome.com/extensions/tabs#method-reload}.
+     * @param {object} reloadProperties Optional. same as the reloadProperties parameter for [chrome.tabs.reload]{@link https://developer.chrome.com/extensions/tabs#method-reload}.
+     * @returns {Promise} Resolves when the tab has finished reloading and holds the result.
+     * The result is an object containing the parameters passed to the callback for [chrome.tabs.onUpdated]{@link https://developer.chrome.com/extensions/tabs#event-onUpdated}.
+     * Rejects if an error is encountered loading the tab, or if it times out. */
     chrome.tabs.reloadAndWait = async function(tabId, reloadProperties) {
         await chrome.tabs.reload(tabId, reloadProperties);
-        const tabLoadCompletePromise = promisifyChromeEvent(chrome.tabs.onUpdated, tabId);
+        const tabLoadCompletePromise = promisifyTabUpdate(tabId);
         const results = await tabLoadCompletePromise;
         return results;
     }


### PR DESCRIPTION
I found it difficult to create a new tab, or reload an existing tab, without having to switch the code execution to a listener function that is called when the tab is finished loading.  So I created a way to do this in one line with the `chrome.tabs.createAndWait` and `chrome.tabs.reloadAndWait` functions.  The functions return when the tab is finished loading (and ready to run a content script)!  They are used like this:

`const {tabId, changeInfo, tab} = await chrome.tabs.createAndWait({ url: "https://www.google.com", active:true });`

`const {tabId, changeInfo, tab} = await chrome.tabs.reloadAndWait(tab.id);`

To accomplish this, I have abstracted the `promisifyRuntimeMessage` function to promisify any kind of chrome.event type, renaming it `promisifyChromeEvent`.  I kept the existing functionality for the `chrome.runtime.onMessage` event, and I added support for the `chrome.tabs.onUpdated` event.  I have found this VERY useful in my personal projects, as I can now create a tab, and run a script on it in only two lines.  Hope you like it!