### PR TITLE
Remove non-standard `contextMenus.create`

### DIFF
--- a/chrome-extension-async.js
+++ b/chrome-extension-async.js
@@ -155,7 +155,7 @@
             { n: 'camera', props: knownInContentSetting },
             { n: 'unsandboxedPlugins', props: knownInContentSetting },
             { n: 'automaticDownloads', props: knownInContentSetting }],
-        contextMenus: ['create', 'update', 'remove', 'removeAll'],
+        contextMenus: ['update', 'remove', 'removeAll'], /* 'create' omitted intentionally, it does not follow standard asynchronous pattern */
         cookies: ['get', 'getAll', 'set', 'remove', 'getAllCookieStores'],
         debugger: ['attach', 'detach', 'sendCommand', 'getTargets'],
         desktopCapture: ['chooseDesktopMedia'],


### PR DESCRIPTION
The await keyword will work fine with the `create` function's return (without a Promise), so by skipping the Promisification of this function, it will work in more cases, namely when used with async/await.  

Unfortunately, this won't work with promise chaining (using `then()`), but that can be managed by wrapping the function with `Promise.resolve()` (eg, `Promise.resolve(chrome.contextMenus.create(props)).then(console.log)`).  I have another idea about how that could also be tackled...  I'll open a separate PR in a bit.

Fixes #23.