### PR TITLE
Handle edge case with no callbackArgs

### DIFF
--- a/chrome-extension-async.js
+++ b/chrome-extension-async.js
@@ -155,7 +155,7 @@
             { n: 'camera', props: knownInContentSetting },
             { n: 'unsandboxedPlugins', props: knownInContentSetting },
             { n: 'automaticDownloads', props: knownInContentSetting }],
-        contextMenus: ['update', 'remove', 'removeAll'], /* 'create' omitted intentionally, it does not follow standard asynchronous pattern */
+        contextMenus: ['create', 'update', 'remove', 'removeAll'],
         cookies: ['get', 'getAll', 'set', 'remove', 'getAllCookieStores'],
         debugger: ['attach', 'detach', 'sendCommand', 'getTargets'],
         desktopCapture: ['chooseDesktopMedia'],

--- a/chrome-extension-async.js
+++ b/chrome-extension-async.js
@@ -31,7 +31,7 @@
             return new Promise((resolve, reject) => {
                 try {
                     // Try to run the original function, with the trimmed args list
-                    f(...safeArgs, (...cbArgs) => {
+                    const ret = f(...safeArgs, (...cbArgs) => {
 
                         // If a callback was passed at the end of the original arguments
                         if (callback) {
@@ -50,7 +50,7 @@
                                 resolve(cbObj);
                             }
                             else if (!cbArgs || cbArgs.length === 0)
-                                resolve();
+                                resolve(ret); // if there were no callback args, resolve with the function's own return value
                             else if (cbArgs.length === 1)
                                 resolve(cbArgs[0]);
                             else


### PR DESCRIPTION
This is an alternative approach to fixing #23.  For chrome functions that pass no arguments to their callbacks, we should try to propagate the function's own return value.

Honestly, I'm pretty confused about how it is even able to work.  It makes sense, kind of, but I'm surprised that I can access the function return inside an arrow function defined as an inline function argument.  In any case, I tested and confirmed that this works.

Fixes #23 and closes #26.